### PR TITLE
Fix dd log env tag issue

### DIFF
--- a/k8s/environments/qa/op-datadog/datadog-agent.yaml
+++ b/k8s/environments/qa/op-datadog/datadog-agent.yaml
@@ -24,6 +24,10 @@ spec:
       env:
         - name: DD_ENV
           value: "qa"
+    process:
+      env:
+        - name: DD_ENV
+          value: "qa"
   clusterAgent:
     config:
       externalMetrics:

--- a/k8s/environments/qa/op-datadog/datadog-agent.yaml
+++ b/k8s/environments/qa/op-datadog/datadog-agent.yaml
@@ -20,6 +20,10 @@ spec:
     env:
       - name: DD_ENV
         value: "qa"
+    config:
+      env:
+        - name: DD_ENV
+          value: "qa"
   clusterAgent:
     config:
       externalMetrics:

--- a/k8s/environments/qa/op-datadog/datadog-agent.yaml
+++ b/k8s/environments/qa/op-datadog/datadog-agent.yaml
@@ -20,14 +20,6 @@ spec:
     env:
       - name: DD_ENV
         value: "qa"
-    config:
-      env:
-        - name: DD_ENV
-          value: "qa"
-    process:
-      env:
-        - name: DD_ENV
-          value: "qa"
   clusterAgent:
     config:
       externalMetrics:

--- a/k8s/environments/qa/op-datadog/datadog-agent.yaml
+++ b/k8s/environments/qa/op-datadog/datadog-agent.yaml
@@ -12,8 +12,6 @@ spec:
       secretName: datadog
       keyName: app-key
   agent:
-    image:
-      name: gcr.io/datadoghq/agent:7.42.2
     apm:
       enabled: true
     log:
@@ -31,8 +29,6 @@ spec:
         - name: DD_ENV
           value: "qa"
   clusterAgent:
-    image:
-      name: gcr.io/datadoghq/agent:7.42.2
     config:
       externalMetrics:
       clusterChecksEnabled: true

--- a/k8s/environments/qa/op-datadog/datadog-agent.yaml
+++ b/k8s/environments/qa/op-datadog/datadog-agent.yaml
@@ -12,6 +12,8 @@ spec:
       secretName: datadog
       keyName: app-key
   agent:
+    image:
+      name: gcr.io/datadoghq/agent:7.42.2
     apm:
       enabled: true
     log:
@@ -29,6 +31,8 @@ spec:
         - name: DD_ENV
           value: "qa"
   clusterAgent:
+    image:
+      name: gcr.io/datadoghq/agent:7.42.2
     config:
       externalMetrics:
       clusterChecksEnabled: true

--- a/k8s/manifests/datadog-operator/Chart.yaml
+++ b/k8s/manifests/datadog-operator/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 
 dependencies:
 - name: datadog-operator
-  version: "0.8.6"
+  version: "0.9.2"
   repository: "https://helm.datadoghq.com"

--- a/k8s/manifests/simple-server/values.qa.yaml
+++ b/k8s/manifests/simple-server/values.qa.yaml
@@ -19,3 +19,15 @@ ingress:
   - hosts:
     - dashboard-qa.simple.org
     secretName: dashboard-qa.simple.org-tls
+server:
+  podAnnotations: {
+    ad.datadoghq.com/log-tailer.logs: '[{"source": "simple-server","service": "simple-server","tags": ["env:qa"]}]'
+  }
+worker:
+  podAnnotations: {
+    ad.datadoghq.com/log-tailer.logs: '[{"source": "simple-server","service": "simple-worker","tags": ["env:qa"]}]'
+  }
+cron:
+  podAnnotations: {
+    ad.datadoghq.com/log-tailer.logs: '[{"source": "simple-server","service": "simple-cron","tags": ["env:qa"]}]'
+  }


### PR DESCRIPTION
Added pod env tag in pod annotation
Ideally, DD should set the env tag as DD_ENV environment variable is configured. Raised a ticket with the Datadog team https://help.datadoghq.com/hc/en-us/requests/1105104 to address this issue 