### PR TITLE
Set postgres job cpu limit in Bangladesh environments

### DIFF
--- a/k8s/environments/bangladesh-production/op-postgres/simple-server.yaml
+++ b/k8s/environments/bangladesh-production/op-postgres/simple-server.yaml
@@ -101,6 +101,9 @@ spec:
           endpoint: s3.ap-south-1.amazonaws.com
           region: ap-south-1
       jobs:
+        resources:
+          limits:
+            cpu: 1
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/environments/bangladesh-staging/op-postgres/simple-server.yaml
+++ b/k8s/environments/bangladesh-staging/op-postgres/simple-server.yaml
@@ -101,6 +101,9 @@ spec:
           endpoint: s3.ap-south-1.amazonaws.com
           region: ap-south-1
       jobs:
+        resources:
+          limits:
+            cpu: 1
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
# Because
Postgres backup job was consuming almost all (t3.samll 2 cores) CPU on the database host