### PR TITLE
Sandbox redis crash fix

### DIFF
--- a/k8s/environments/sandbox/argocd-apps/apps.yaml
+++ b/k8s/environments/sandbox/argocd-apps/apps.yaml
@@ -355,6 +355,7 @@ spec:
     helm:
       valueFiles:
         - values.affinity-worker.yaml
+        - ../../environments/sandbox/values/worker-redis.yaml
   project: default
   syncPolicy:
     syncOptions:

--- a/k8s/environments/sandbox/values/worker-redis.yaml
+++ b/k8s/environments/sandbox/values/worker-redis.yaml
@@ -1,0 +1,3 @@
+redis:
+  commonConfiguration: |-
+    maxmemory 6gb

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -88,7 +88,7 @@ module "eks" {
   metabase_instance_count = 1
 
   cache_redis_instance_type  = "t3.small"
-  worker_redis_instance_type = "t3.small"
+  worker_redis_instance_type = "t3.large"
 
   default_nodepool_instance_type  = "t3.medium"
   default_nodepool_instance_count = 3


### PR DESCRIPTION
- Increase Redis instance to t3.large (8gb memory)
- Set maxmemory Redis config to 6gb