### PR TITLE
Increase request timeouts for metabase in india and bangladesh production

### DIFF
--- a/k8s/environments/bangladesh-production/values/metabase.yaml
+++ b/k8s/environments/bangladesh-production/values/metabase.yaml
@@ -7,6 +7,9 @@ metabase:
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy‑read‑timeout: 600
+      nginx.ingress.kubernetes.io/proxy‑connect‑timeout: 600
+      nginx.ingress.kubernetes.io/proxy‑send‑timeout: 600
     hosts:
       - host: metabase.bd.simple.org
         paths:

--- a/k8s/environments/india-production/values/metabase.yaml
+++ b/k8s/environments/india-production/values/metabase.yaml
@@ -7,6 +7,9 @@ metabase:
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy‑read‑timeout: 600
+      nginx.ingress.kubernetes.io/proxy‑connect‑timeout: 600
+      nginx.ingress.kubernetes.io/proxy‑send‑timeout: 600
     hosts:
       - host: metabase.simple.org
         paths:


### PR DESCRIPTION
Increasing the timeouts for metabase in order to allow long running queries and prevent this screen. The default of 60 secs is usually not enough for data analysis on large tables

<img width="651" alt="Screenshot 2023-12-29 at 14 55 29" src="https://github.com/simpledotorg/container-deployment/assets/3933133/5ecf0807-99aa-465b-b230-b7b710f97361">
