### PR TITLE
Create grafana tables for showing slow request paths

### DIFF
--- a/k8s/manifests/kube-prometheus/lib/simple-server/database-dashboard.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server/database-dashboard.libsonnet
@@ -84,7 +84,7 @@ local database =
     ),
   ]);
 
-g.dashboard.new('Simple Database Dasboard')
+g.dashboard.new('Simple Database Dashboard')
 + g.dashboard.withUid('simple-database-dashboard')
 + g.dashboard.withDescription('Simple database dashboard')
 + g.dashboard.withTimezone('browser')

--- a/k8s/manifests/kube-prometheus/lib/simple-server/server-dashboard.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server/server-dashboard.libsonnet
@@ -95,6 +95,30 @@ local load_balancer =
       g.query.prometheus.withInstant(true) +
       g.query.prometheus.withFormat('table'),
     ]),
+    utils.table('Slow requests in last 24 hours', [
+      query(
+        |||
+          topk(10, avg(
+           (rate(ruby_http_request_duration_seconds_sum[1d]) /
+            rate(ruby_http_request_duration_seconds_count[1d])))
+          by (controller, path))
+        |||
+      ) +
+      g.query.prometheus.withInstant(true) +
+      g.query.prometheus.withFormat('table'),
+    ]),
+    utils.table('Slow requests in selected range', [
+      query(
+        |||
+          topk(10, avg(
+           (rate(ruby_http_request_duration_seconds_sum[$__range]) /
+            rate(ruby_http_request_duration_seconds_count[$__range])))
+          by (controller, path))
+        |||
+      ) +
+      g.query.prometheus.withInstant(true) +
+      g.query.prometheus.withFormat('table'),
+    ]),
     utils.table('Most frequent actions in selected range', [
       query(
         |||
@@ -120,7 +144,7 @@ local load_balancer =
     ]),
   ]);
 
-g.dashboard.new('Simple Server Dasboard')
+g.dashboard.new('Simple Server Dashboard')
 + g.dashboard.withUid('simple-server-dashboard')
 + g.dashboard.withDescription('Simple server dashboard')
 + g.dashboard.withTimezone('browser')

--- a/k8s/manifests/kube-prometheus/lib/simple-server/sync-dashboard.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server/sync-dashboard.libsonnet
@@ -53,7 +53,7 @@ local sync_from_user =
     ]),
   ]);
 
-g.dashboard.new('Simple Sync Dasboard')
+g.dashboard.new('Simple Sync Dashboard')
 + g.dashboard.withUid('simple-sync-dashboard')
 + g.dashboard.withDescription('Simple sync dashboard')
 + g.dashboard.withTimezone('browser')


### PR DESCRIPTION
This will be merged along with some application side changes in: https://github.com/simpledotorg/simple-server/pull/5456

New tables in dashboard after this change (left-middle and middle):
![image](https://github.com/user-attachments/assets/9fe07ec9-f0a7-4457-8331-45de04bf2b0e)
