### PR TITLE
Disable datadog metrics and apm from bd prod env

### DIFF
--- a/k8s/environments/bangladesh-production/op-datadog/datadog-agent.yaml
+++ b/k8s/environments/bangladesh-production/op-datadog/datadog-agent.yaml
@@ -7,8 +7,14 @@ spec:
   override:
     nodeAgent:
       env:
-        - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
-          value: "true"
+        - name: DD_ENABLE_PAYLOADS_EVENTS
+          value: "false"
+        - name: DD_ENABLE_PAYLOADS_SERIES
+          value: "false"
+        - name: DD_ENABLE_PAYLOADS_SERVICE_CHECKS
+          value: "false"
+        - name: DD_ENABLE_PAYLOADS_SKETCHES
+          value: "false"
   global:
     logLevel: "error"
     clusterName: "bangladesh-production-k8s"
@@ -25,4 +31,4 @@ spec:
     logCollection:
       enabled: true
     apm:
-      enabled: true
+      enabled: false


### PR DESCRIPTION
**Story card:** [sc-13310](https://app.shortcut.com/simpledotorg/story/13310)

Datadog document: https://docs.datadoghq.com/logs/guide/how-to-set-up-only-logs/?tab=kubernetes