### PR TITLE
Add dashboard for mat view refreshes

### DIFF
--- a/k8s/manifests/kube-prometheus/lib/simple-server.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server.libsonnet
@@ -5,6 +5,7 @@ local grafanaDashboards = { grafanaDashboards: {
   'simple-server.json': (import 'simple-server/server-dashboard.libsonnet'),
   'simple-sync.json': (import 'simple-server/sync-dashboard.libsonnet'),
   'simple-database.json': (import 'simple-server/database-dashboard.libsonnet'),
+  'matview-refresh.json': (import 'simple-server/matview-dashboard.libsonnet'),
 } };
 
 local prometheusRules = (import 'simple-server/prometheus-rules.libsonnet');

--- a/k8s/manifests/kube-prometheus/lib/simple-server/matview-dashboard.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server/matview-dashboard.libsonnet
@@ -1,0 +1,22 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+
+local utils = (import './dashboard-utils.libsonnet');
+local query = utils.query;
+
+local refreshes =
+      utils.timeSeries('MatView Refresh Duration', [
+        query('ruby_reporting_views_refresh_duration_seconds', 'view!="all"'),
+      ])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.withAxisLabel('seconds')
+      + g.panel.timeSeries.options.legend.withIsVisible(false);
+
+g.dashboard.new('MatView Refresh Dashboard')
++ g.dashboard.withUid('matview-refresh-dashboard')
++ g.dashboard.withDescription('Matview Refresh durations')
++ g.dashboard.withTimezone('browser')
++ g.dashboard.withVariables([utils.datasource])
++ g.dashboard.withPanels(
+  g.util.grid.makeGrid([
+    refreshes,
+  ])
+)


### PR DESCRIPTION
**Story card:** [sc-13471](https://app.shortcut.com/simpledotorg/story/13471/create-dashboards-and-alerts-for-metrics-migrated-from-datadog)