### PR TITLE
Update EKS cluster version to 1.31

### DIFF
--- a/terraform/systems-production/main.tf
+++ b/terraform/systems-production/main.tf
@@ -65,7 +65,7 @@ module "eks" {
   subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_name    = local.cluster_name
-  cluster_version = "1.28"
+  cluster_version = "1.31"
   tags            = local.tags
   key_pair_name   = aws_key_pair.simple_aws_key.key_name
 


### PR DESCRIPTION
Upgraded the Amazon EKS cluster version from 1.28 to 1.31 in the Terraform configuration. This change ensures compatibility with the latest features and security enhancements provided by Kubernetes and AWS.

**Story card:** [sc-13558](https://app.shortcut.com/simpledotorg/story/13558)