### PR TITLE
SC-13552: Update EKS cluster version to 1.31

### DIFF
--- a/terraform/bangladesh-staging/main.tf
+++ b/terraform/bangladesh-staging/main.tf
@@ -71,7 +71,7 @@ module "eks" {
   subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_name    = local.cluster_name
-  cluster_version = "1.28"
+  cluster_version = "1.31"
   tags            = local.tags
   key_pair_name   = aws_key_pair.simple_aws_key.key_name
 


### PR DESCRIPTION
Updated the Kubernetes cluster version from 1.28 to 1.31 in the Bangladesh staging environment. This change ensures compatibility with the latest Kubernetes features and security enhancements.

**Story card:** [sc-13552] (https://app.shortcut.com/simpledotorg/story/13552/upgrade-bd-staging-sandbox-k8s-cluster)