### PR TITLE
SC-13551:Update EKS cluster version to 1.31

### DIFF
--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -69,7 +69,7 @@ module "eks" {
   subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_name    = local.cluster_name
-  cluster_version = "1.28"
+  cluster_version = "1.31"
   tags            = local.tags
   key_pair_name   = aws_key_pair.simple_aws_key.key_name
 


### PR DESCRIPTION
This change updates the EKS cluster version from 1.28 to 1.31 in the sandbox environment. The commitment ensures compatibility with newer AWS features and improvements provided in version 1.31.

**Story card:** [sc-13551](https://app.shortcut.com/simpledotorg/story/13551/upgrade-sandbox-k8s-cluster)