### PR TITLE
SC-13554:Update EKS cluster_version to 1.31

### DIFF
--- a/terraform/bangladesh-production/main.tf
+++ b/terraform/bangladesh-production/main.tf
@@ -69,7 +69,7 @@ module "eks" {
   subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_name    = local.cluster_name
-  cluster_version = "1.28"
+  cluster_version = "1.31"
   tags            = local.tags
   key_pair_name   = aws_key_pair.simple_aws_key.key_name
 


### PR DESCRIPTION
Updated the Kubernetes cluster version in the production environment configuration from 1.28 to 1.31. This change ensures compatibility with newer features and security improvements in the latest Kubernetes release.

**Story card:** [sc-13554](https://app.shortcut.com/simpledotorg/story/13554/upgrade-bd-prod-k8s-cluster)