### PR TITLE
sc-13557:Update EKS cluster version to 1.31.

### DIFF
--- a/terraform/india-production/main.tf
+++ b/terraform/india-production/main.tf
@@ -71,7 +71,7 @@ module "eks" {
   subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_name    = local.cluster_name
-  cluster_version = "1.28"
+  cluster_version = "1.31"
   tags            = local.tags
   key_pair_name   = aws_key_pair.simple_aws_key.key_name
 


### PR DESCRIPTION
Upgraded the Kubernetes EKS cluster version from 1.28 to 1.31. This ensures compatibility with newer features and security improvements. Configuration change affects the `main.tf` file in the India production environment.

**Story card:** [sc-13557](https://app.shortcut.com/simpledotorg/story/13557/upgrade-india-prod-k8s-cluster)