### PR TITLE
add human-readable units to Simple dashboards

### DIFF
--- a/k8s/manifests/kube-prometheus/lib/simple-server/database-dashboard.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server/database-dashboard.libsonnet
@@ -18,7 +18,7 @@ local database =
           |||
         ),
       ],
-    ),
+    ) + g.panel.timeSeries.standardOptions.withUnit('Bps'),
     utils.timeSeries(
       'Latency', [
         query(
@@ -27,7 +27,7 @@ local database =
           |||
         ),
       ],
-    ),
+    ) + g.panel.timeSeries.standardOptions.withUnit('ms'),
     utils.timeSeries(
       'Active Connections', [
         query(
@@ -45,7 +45,7 @@ local database =
           |||
         ),
       ],
-    ),
+    ) + g.panel.timeSeries.standardOptions.withUnit('percent'),
     utils.timeSeries(
       'Memory Usage', [
         query(
@@ -54,7 +54,7 @@ local database =
           |||
         ),
       ],
-    ),
+    ) + g.panel.timeSeries.standardOptions.withUnit('bytes'),
     utils.timeSeries(
       'Available disk space', [
         query(
@@ -63,7 +63,7 @@ local database =
           |||
         ),
       ],
-    ),
+    ) + g.panel.timeSeries.standardOptions.withUnit('bytes'),
     utils.timeSeries(
       'Query Rate', [
         query(
@@ -81,7 +81,7 @@ local database =
           |||
         ),
       ],
-    ),
+    ) + g.panel.timeSeries.standardOptions.withUnit('bytes'),
   ]);
 
 g.dashboard.new('Simple Database Dashboard')

--- a/k8s/manifests/kube-prometheus/lib/simple-server/server-dashboard.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server/server-dashboard.libsonnet
@@ -38,6 +38,7 @@ local load_balancer =
       query('sum(rate(ruby_http_request_duration_seconds_count{controller!~"api/.+"}[$__rate_interval])) > 0', 'Dashboard'),
     ])
     + g.panel.timeSeries.fieldConfig.defaults.custom.withAxisLabel('Req/sec')
+    + g.panel.timeSeries.standardOptions.withUnit('reqps')
     + g.panel.timeSeries.options.legend.withIsVisible(false),
     utils.timeSeries('Non 2xx', [
       query('sum by(status) (rate(ruby_http_requests_total{status!~"2.."}[$__rate_interval])) > 0', 'All'),
@@ -63,7 +64,8 @@ local load_balancer =
             / irate(ruby_http_request_duration_seconds_count{controller!~"api/.+"}[$__rate_interval]) > 0)
         |||, 'All'
       ),
-    ]),
+    ])
+    + g.panel.timeSeries.standardOptions.withUnit('s'),
     utils.barGauge('Nginx Connections', [
       query(
         |||

--- a/k8s/manifests/kube-prometheus/lib/simple-server/sync-dashboard.libsonnet
+++ b/k8s/manifests/kube-prometheus/lib/simple-server/sync-dashboard.libsonnet
@@ -15,10 +15,10 @@ local sync_to_user =
     utils.timeSeries('Latency', [
       query(
         |||
-          sum by(controller) (rate(ruby_http_request_duration_seconds_sum{action="sync_to_user"}[$__rate_interval])) * 1000
+          sum by(controller) (rate(ruby_http_request_duration_seconds_sum{action="sync_to_user"}[$__rate_interval]))
         |||
       ),
-    ]),
+    ]) + g.panel.timeSeries.standardOptions.withUnit('s'),
     utils.timeSeries('Error Rate', [
       query(
         |||
@@ -40,10 +40,10 @@ local sync_from_user =
     utils.timeSeries('Latency', [
       query(
         |||
-          sum by(controller) (rate(ruby_http_request_duration_seconds_sum{action="sync_from_user"}[$__rate_interval])) * 1000
+          sum by(controller) (rate(ruby_http_request_duration_seconds_sum{action="sync_from_user"}[$__rate_interval]))
         |||
       ),
-    ]),
+    ]) + g.panel.timeSeries.standardOptions.withUnit('s'),
     utils.timeSeries('Error Rate', [
       query(
         |||


### PR DESCRIPTION
**Story card:** [sc-14277](https://app.shortcut.com/simpledotorg/story/14277/fix-the-units-on-grafana-dashboards)

This change makes the units show up more clearly on the dashboard. The units adapt to the value of the metric.

## Example: Simple Database Dashboard (see units in Y-Axis)

### Before:
<img width="2255" alt="image" src="https://github.com/user-attachments/assets/9246b422-5106-4c1e-9ab7-6d07b1ea6130">

### After:
<img width="2254" alt="image" src="https://github.com/user-attachments/assets/eb145a53-ece3-4539-b1fe-bd11475bc412">
