### PR TITLE
sc-13556:Update k3s versions for staging and production

### DIFF
--- a/ansible/group_vars/sri_lanka_production/vars.yml
+++ b/ansible/group_vars/sri_lanka_production/vars.yml
@@ -40,4 +40,4 @@ k3s_server:
   - traefik # Disable traefik ingress controller.
   node-label: "{{ k3s_node_labels }}"
 
-k3s_release_version: v1.28.5+k3s1
+k3s_release_version: v1.28.15+k3s1

--- a/ansible/group_vars/sri_lanka_staging/vars.yml
+++ b/ansible/group_vars/sri_lanka_staging/vars.yml
@@ -36,4 +36,4 @@ k3s_server:
   - traefik # Disable traefik ingress controller.
   node-label: "{{ k3s_node_labels }}"
 
-k3s_release_version: v1.28.5+k3s1
+k3s_release_version: v1.31.2+k3s1


### PR DESCRIPTION
Upgraded k3s to v1.31.2+k3s1 in staging and v1.28.15+k3s1 in production to enhance compatibility and stability. These changes ensure alignment with the latest supported versions in respective environments.

**Story card:** [sc-13556](https://app.shortcut.com/simpledotorg/story/13556/upgrade-lk-prod-staging-k8s-cluster)