### PR TITLE
Enabling hot_standby_feedback for SL prod

### DIFF
--- a/k8s/environments/sri-lanka-production/op-postgres/simple-server.yaml
+++ b/k8s/environments/sri-lanka-production/op-postgres/simple-server.yaml
@@ -120,6 +120,7 @@ spec:
           max_parallel_workers_per_gather: "4"
           max_parallel_workers: "8"
           max_parallel_maintenance_workers: "4"
+          hot_standby_feedback: "on"
   monitoring:
     pgmonitor:
       exporter:


### PR DESCRIPTION
**Story card:** [sc-14364](https://app.shortcut.com/simpledotorg/story/14364/medication-titration-report-not-working)

Enabling hot_standby_feedback for SL prod which in turn should improve query performances on replica database.