### PR TITLE
Increasing metabase timeout for sl prod

### DIFF
--- a/k8s/environments/sri-lanka-production/values/metabase.yaml
+++ b/k8s/environments/sri-lanka-production/values/metabase.yaml
@@ -10,6 +10,9 @@ metabase:
         if ($request_method = OPTIONS ) {
           return 405;
         }
+      nginx.ingress.kubernetes.io/proxy-read-timeout: 600
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: 600
+      nginx.ingress.kubernetes.io/proxy-send-timeout: 600
     className: "nginx"
     hosts:
       - host: simples9.health.gov.lk


### PR DESCRIPTION
**Story card:** [sc-14364](https://app.shortcut.com/simpledotorg/story/14364/sl-medication-titration-report-not-working#activity-14485)

Increasing the timeout for SL prod. Currently it times out after 1 min.
This is done in accordance with https://github.com/simpledotorg/container-deployment/pull/83