### PR TITLE
Remove unused server, worker, and cron configurations

### DIFF
--- a/k8s/environments/qa/values/simple.yaml
+++ b/k8s/environments/qa/values/simple.yaml
@@ -19,7 +19,4 @@ ingress:
   - hosts:
     - dashboard-qa.simple.org
     secretName: dashboard-qa.simple.org-tls
-server:
-worker:
-cron:
 


### PR DESCRIPTION
These configurations were not being utilized and have been removed to simplify the QA values file. This helps reduce clutter and ensures only relevant settings are maintained.