### PR TITLE
Remove deprecated server, worker, and cron configurations.

### DIFF
--- a/k8s/environments/bangladesh-production/values/simple.yaml
+++ b/k8s/environments/bangladesh-production/values/simple.yaml
@@ -20,20 +20,6 @@ ingress:
   - hosts:
     - dashboard.bd.simple.org
     secretName: dashboard.bd.simple.org-tls
-cron:
-  enabled: true
-  log:
-    storage: 10Gi
-
-server:
-  log:
-    storage: 10Gi
-
-worker:
-  enabled: true
-  log:
-    storage: 50Gi
-
 migration:
   enabled: true
 metrics:

--- a/k8s/environments/bangladesh-staging/values/simple.yaml
+++ b/k8s/environments/bangladesh-staging/values/simple.yaml
@@ -34,11 +34,6 @@ ingress:
   - hosts:
     - dashboard-demo.simple.org
     secretName: dashboard-demo.simple.org-tls
-cron:
-  enabled: true
-server:
-worker:
-  enabled: true
 migration:
   enabled: true
 metrics:

--- a/k8s/environments/india-production/values/simple.yaml
+++ b/k8s/environments/india-production/values/simple.yaml
@@ -23,10 +23,6 @@ ingress:
   - hosts:
     - dashboard.simple.org
     secretName: dashboard.simple.org-tls
-cron:
-  enabled: true
-  log:
-    storage: 10Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -45,20 +41,7 @@ cron:
             values:
             - "replica"
         topologyKey: "kubernetes.io/hostname"
-server:
-  replicaCount: 6
-  log:
-    storage: 10Gi
-worker:
-  enabled: true
-  replicaCount: 2
-  log:
-    storage: 100Gi
 migration:
   enabled: true
-workerCphc:
-  enabled: false
-  log:
-    storage: 10Gi
 metrics:
   enabled: true

--- a/k8s/environments/sandbox/values/simple.yaml
+++ b/k8s/environments/sandbox/values/simple.yaml
@@ -20,14 +20,6 @@ ingress:
   - hosts:
     - dashboard-sandbox.simple.org
     secretName: dashboard-sandbox.simple.org-tls
-cron:
-  enabled: true
-server:
-  replicaCount: 1
-worker:
-  enabled: true
-  log:
-    storage: 20Gi
 migration:
   enabled: true
 workerCphc:

--- a/k8s/environments/sri-lanka-production/values/simple.yaml
+++ b/k8s/environments/sri-lanka-production/values/simple.yaml
@@ -14,11 +14,6 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-cron:
-  enabled: true
-server:
-worker:
-  enabled: true
 migration:
   enabled: true
 metrics:

--- a/k8s/environments/sri-lanka-staging/values/simple.yaml
+++ b/k8s/environments/sri-lanka-staging/values/simple.yaml
@@ -33,8 +33,5 @@ ingress:
   - hosts:
     - dashboard-demo.lk.simple.org
     secretName: dashboard-demo.lk.simple.org-tls
-server:
-worker:
-cron:
 migration:
   enabled: false


### PR DESCRIPTION
This commit removes the unused and deprecated `server`, `worker`, and `cron` configurations across various environment files. The cleanup simplifies the configuration files, aligning them with current deployment requirements. No functional changes are introduced as these fields were no longer in use.