### PR TITLE
Upgrade EKS cluster version to 1.32

### DIFF
--- a/terraform/india-production/main.tf
+++ b/terraform/india-production/main.tf
@@ -71,7 +71,7 @@ module "eks" {
   subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_name    = local.cluster_name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
   tags            = local.tags
   key_pair_name   = aws_key_pair.simple_aws_key.key_name
 


### PR DESCRIPTION
Updated the EKS cluster version from 1.31 to 1.32 in the Terraform configuration for India production. This ensures compatibility with the latest features and improvements. No other changes were made to the configuration.