### PR TITLE
Update EKS cluster version to 1.32

### DIFF
--- a/terraform/systems-production/main.tf
+++ b/terraform/systems-production/main.tf
@@ -65,7 +65,7 @@ module "eks" {
   subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_name    = local.cluster_name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
   tags            = local.tags
   key_pair_name   = aws_key_pair.simple_aws_key.key_name
 


### PR DESCRIPTION
Upgraded the Kubernetes cluster version from 1.31 to 1.32 in the production environment Terraform configuration. This ensures compatibility with the latest features and security updates.

**Story card:** [sc-14927](https://app.shortcut.com/simpledotorg/story/14927/upgrade-developement-systems-production-01-k8s-cluster-1-31-to-1-32)