### PR TITLE
Temporarily pause sync on SBX

### DIFF
--- a/k8s/environments/sandbox/argocd-apps/apps.yaml
+++ b/k8s/environments/sandbox/argocd-apps/apps.yaml
@@ -20,9 +20,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -48,9 +46,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -72,9 +68,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -101,9 +95,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -129,9 +121,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -154,9 +144,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -178,9 +166,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -202,9 +188,7 @@ spec:
       - PruneLast=true
       - CreateNamespace=true
       - ServerSideApply=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -227,9 +211,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -255,9 +237,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -284,9 +264,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -313,9 +291,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -342,9 +318,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -366,9 +340,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -397,9 +369,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -424,9 +394,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -452,9 +420,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -477,9 +443,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -504,9 +468,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -529,9 +491,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -556,9 +516,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -581,9 +539,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -608,9 +564,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -633,9 +587,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -660,9 +612,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -685,9 +635,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -712,9 +660,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -737,9 +683,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -764,9 +708,7 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: true
-      selfHeal: true
+    automated: false
 
 ---
 
@@ -789,7 +731,5 @@ spec:
     syncOptions:
       - PruneLast=true
       - CreateNamespace=true
-    automated:
-      prune: false
-      selfHeal: true
+    automated: false
 


### PR DESCRIPTION
This temporarily pauses the sync in sandbox, so we can reconnect the old persistent volumes
