### PR TITLE
remove some loki grafana dashboards

### DIFF
--- a/k8s/manifests/kube-prometheus/vendor/github.com/grafana/loki/production/loki-mixin/dashboards.libsonnet
+++ b/k8s/manifests/kube-prometheus/vendor/github.com/grafana/loki/production/loki-mixin/dashboards.libsonnet
@@ -1,7 +1,6 @@
 (import 'dashboards/loki-retention.libsonnet') +
 (import 'dashboards/loki-chunks.libsonnet') +
 (import 'dashboards/loki-logs.libsonnet') +
-(import 'dashboards/loki-operational.libsonnet') +
 (import 'dashboards/loki-resources-overview.libsonnet') +
 (import 'dashboards/loki-reads.libsonnet') +
 (import 'dashboards/loki-reads-resources.libsonnet') +
@@ -9,6 +8,4 @@
 (import 'dashboards/loki-writes-resources.libsonnet') +
 (import 'dashboards/loki-deletion.libsonnet') +
 (import 'dashboards/loki-canary-dashboard.libsonnet') +
-(import 'dashboards/recording-rules.libsonnet') +
-(import 'dashboards/loki-bloom-build.libsonnet') +
-(import 'dashboards/loki-bloom-gateway.libsonnet')
+(import 'dashboards/recording-rules.libsonnet')


### PR DESCRIPTION
**Story card:** [sc-15780](https://app.shortcut.com/simpledotorg/story/15780/remove-grafana-dashboard-loki-operational-grafana-dashboard-loki-bloom-gateway-and-grafana-dashboard-loki-bloom-build-grafana)