### PR TITLE
chore: Temporarily pause SBX self-heal

### DIFF
--- a/k8s/environments/sandbox/root-app.yaml
+++ b/k8s/environments/sandbox/root-app.yaml
@@ -18,4 +18,4 @@ spec:
       - CreateNamespace=true
     automated:
       prune: false
-      selfHeal: true
+      selfHeal: false


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

This should stop ArgoCD from recreating pods according to spec. 

> [!WARNING]
> This should be rolled back as soon as we have the cluster in some steady state

> [!CAUTION]
> Before we roll this back, we must ensure that turning this back on will not undo any work we've done to get the cluster in a steady state
