### PR TITLE
updating backup retention policy for BD prod

### DIFF
--- a/k8s/environments/bangladesh-production/op-postgres/simple-server.yaml
+++ b/k8s/environments/bangladesh-production/op-postgres/simple-server.yaml
@@ -75,8 +75,8 @@ spec:
                   - "true"
       global:
         # Number of full backups to retain
-        repo1-retention-full: "2" 
-        repo2-retention-full: "2"
+        repo1-retention-full: "1"
+        repo2-retention-full: "4"
         repo2-path: /pgbackrest/postgres-operator/simple/repo2
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.40-1
       repos:


### PR DESCRIPTION
**Story card:** [sc-16264](https://app.shortcut.com/simpledotorg/story/16264/bd-update-db-backup-retention-policy)

We need to update the backup retention policy to prevent the disk volume getting full for simple-repo-host.

Updated backup retention policy

repo1 (simple-repo-host) should keep last 1 weeks backup . This translates to 1 full backup and 6 differential backups.
repo2 (s3) should keep last 1 month's backup. This translates to 4 full backups and differential backups for the rest of the days.