### PR TITLE
upgrading htn tracking dhis2 to 2.40.8.2

### DIFF
--- a/k8s/environments/sandbox/values/dhis2-htn-tracking.yaml
+++ b/k8s/environments/sandbox/values/dhis2-htn-tracking.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 2.40.5.0
+  tag: 2.40.8.2
 ingress:
   enabled: true
   className: "nginx"


### PR DESCRIPTION
**Story card:** [sc-16270](https://app.shortcut.com/simpledotorg/story/16270/upgrade-critical-dhis2-instances-to-the-latest-dhis2-patch)