### PR TITLE
fix os image for semaphore deployment

### DIFF
--- a/.semaphore/docker.yml
+++ b/.semaphore/docker.yml
@@ -31,4 +31,4 @@ blocks:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Start
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 blocks:
   - name: Checkout
     task:

--- a/.semaphore/update_dhis2_dev_ssh_keys.yml
+++ b/.semaphore/update_dhis2_dev_ssh_keys.yml
@@ -18,4 +18,4 @@ blocks:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404

--- a/.semaphore/update_qa_ssh_keys.yml
+++ b/.semaphore/update_qa_ssh_keys.yml
@@ -18,4 +18,4 @@ blocks:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404

--- a/.semaphore/update_sri_lanka_production_jumpbox_keys.yml
+++ b/.semaphore/update_sri_lanka_production_jumpbox_keys.yml
@@ -18,4 +18,4 @@ blocks:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404

--- a/.semaphore/update_test_env_ssh_keys.yml
+++ b/.semaphore/update_test_env_ssh_keys.yml
@@ -18,4 +18,4 @@ blocks:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404


### PR DESCRIPTION
Fix Deployment issue with semaphore. Old ubuntu image is no more available and throwing below error:

Unknown machine type 'e1-standard-2' with os image 'ubuntu2004'