### PR TITLE
scale up Metabase node instance type

### DIFF
--- a/terraform/bangladesh-production/main.tf
+++ b/terraform/bangladesh-production/main.tf
@@ -106,7 +106,7 @@ module "eks" {
   worker_instance_count  = 1
 
   metabase_instance_enable = true
-  metabase_instance_type   = "t3.small"
+  metabase_instance_type   = "t3.medium"
   metabase_instance_count  = 1
 
   cache_redis_instance_enable = true


### PR DESCRIPTION
**Ticket**: [503 error when loading metabase BD](https://rtsl.atlassian.net/browse/SIMPLEBACK-142)

### **Because**

1. Metabase pod was getting evicted due to memory pressure on the t3.small node.
2. After the Metabase upgrade, the workload required more memory than the available node capacity.

### **This addresses**

Upgrades the Metabase node instance type from t3.small to t3.medium.

### **Test Instruction**

1. Verify Metabase pod is running without eviction.
2. Access https://metabase.bd.simple.org/ and confirm the dashboard loads successfully.