### PR TITLE
Fix docker build

### DIFF
--- a/docker/simple-server-base.Dockerfile
+++ b/docker/simple-server-base.Dockerfile
@@ -2,6 +2,10 @@ FROM phusion/passenger-customizable:2.0.1
 
 RUN rm -rf /usr/local/rvm /etc/profile.d/rvm.sh
 
+# Remove the Phusion Passenger apt repo — its GPG key (D870AB033FB45BD1) is expired
+# and we don't install anything from it (Ruby is built from source below)
+RUN rm -f /etc/apt/sources.list.d/passenger.list
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   libssl-dev \


### PR DESCRIPTION
**Ticket:** [Remove stale Passenger apt repository from base image](https://rtsl.atlassian.net/browse/SIMPLEBACK-144)

### **Because**
The base image's Passenger apt repo (/etc/apt/sources.list.d/passenger.list) has an expired GPG key (D870AB033FB45BD1), causing apt-get update to fail on every Docker build.

### **This addresses**
Removes the stale passenger.list file before apt-get update runs. Safe to remove — we don't install anything from that repo (Passenger ships with the base image, Ruby is built from source).

### **Test instructions**

1. Run the Docker build (docker.yml / Semaphore) on this branch and confirm it completes without the apt-get update GPG/signature error.
2. Confirm the resulting image still builds and runs as expected (no functional change expected).